### PR TITLE
Updated NEWS for v1.6.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,16 @@
+pipeline-mod-nlb v1.6.0
+=======================
+
+Includes
+--------
+- NLB-specific scripts from DTBook, HTML and EPUB3 to PEF
+  (https://github.com/snaekobbi/pipeline-mod-nlb/pull/22)
+- Remove 5-2 surrounding other languages when using the norwegian braille table
+  (https://github.com/snaekobbi/pipeline-mod-nlb/issues/25)
+- Allow all languages as input
+- Do not perform contractions for foreign languages
+- Handle multiple authors and contributors on title page
+
 pipeline-mod-nlb v1.5.0
 =======================
 
@@ -7,7 +20,6 @@ Includes
   (https://github.com/snaekobbi/pipeline-mod-nlb/issues/18)
 - Treat `strong` as `em` when no `em` present
   (https://github.com/snaekobbi/pipeline-mod-nlb/issues/2)
-
 
 pipeline-mod-nlb v1.4.0
 =======================

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.daisy.pipeline.modules.braille</groupId>
     <artifactId>braille-modules-parent</artifactId>
-    <version>1.9.10-SNAPSHOT</version>
+    <version>1.9.10</version>
     <relativePath />
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>mod-nlb</artifactId>
-  <version>1.6.0</version>
+  <version>1.6.1-SNAPSHOT</version>
   <packaging>bundle</packaging>
 
   <name>DP2 Braille Modules :: NLB</name>
@@ -218,8 +218,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <scm>
-    <tag>v1.6.0</tag>
-  </scm>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>mod-nlb</artifactId>
-  <version>1.6.0-SNAPSHOT</version>
+  <version>1.6.0</version>
   <packaging>bundle</packaging>
 
   <name>DP2 Braille Modules :: NLB</name>
@@ -218,4 +218,8 @@
       </plugin>
     </plugins>
   </build>
+
+  <scm>
+    <tag>v1.6.0</tag>
+  </scm>
 </project>


### PR DESCRIPTION
Blocked on: release braille-modules-parent v1.9.10

@bertfrees I wrote the release notes, but I won't release until the snapshot dependency on braille-modules-parent is resolved so I'll leave it in this PR for now.
